### PR TITLE
MANTA-4852 rename manta-picker service to something more accurate

### DIFF
--- a/tools/jr-manifest.json
+++ b/tools/jr-manifest.json
@@ -366,13 +366,13 @@
             "name": "manta-physusage"
         },
         {
-            "name": "manta-picker",
+            "name": "manta-storinfo",
             "labels": {
                 "release": true,
                 "vm": true,
-                "mg": "manta-picker",
-                "mantaservice": "picker",
-                "image": "mantav2-picker"
+                "mg": "manta-storinfo",
+                "mantaservice": "storinfo",
+                "image": "mantav2-storinfo"
             }
         },
         {


### PR DESCRIPTION
I haven't actually renamed the manta-picker repo itself, yet.  But my plan is to do that immediately after pushing the MANTA-4852 changes to all four affected repos (manta-picker, sdc-manta, manta and manta-rebalancer).